### PR TITLE
Add ability to update datasets' summaries

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,6 +57,11 @@ When in a datakit project, you'll have two new commands:
     project's ``data/public`` directory, but you can specify a different
     directory with ``--source-dir``.
 
+  * ``datakit dworld summary``, which updates the dataset's overall Markdown
+    summary on data.world. This assumes a Markdown file exists at
+    ``publish/distro_summary.md``; if that is not present, it creates one based
+    on the dataset's existing summary.
+
 
 Credits
 ========

--- a/datakit_dworld/create.py
+++ b/datakit_dworld/create.py
@@ -36,12 +36,8 @@ class Create(DworldMixin, CommandHelpers, Command):
     def create_dataset(self, payload):
         url = 'https://api.data.world/v0/datasets/{0}'.format(
             self.configs['username'])
-        headers = {
-            'Authorization': 'Bearer {0}'.format(self.configs['api_token']),
-            'Content-Type': 'application/json',
-        }
 
-        r = requests.post(url, json=payload, headers=headers)
+        r = requests.post(url, json=payload, headers=self.get_auth_headers())
         r.raise_for_status()
 
         dataset_url = r.json()['uri']

--- a/datakit_dworld/dworld_mixin.py
+++ b/datakit_dworld/dworld_mixin.py
@@ -12,8 +12,12 @@ class DworldMixin(object):
             'Content-Type': 'application/json',
         }
 
+    def get_project_path(self):
+        return os.getcwd()
+
     def get_settings_path(self):
-        return os.path.join(os.getcwd(), 'config', 'datakit-dworld.json')
+        return os.path.join(
+            self.get_project_path(), 'config', 'datakit-dworld.json')
 
     def get_settings_data(self):
         settings_data = {}

--- a/datakit_dworld/dworld_mixin.py
+++ b/datakit_dworld/dworld_mixin.py
@@ -6,6 +6,12 @@ import os
 class DworldMixin(object):
     plugin_slug = 'datakit-dworld'
 
+    def get_auth_headers(self):
+        return {
+            'Authorization': 'Bearer {0}'.format(self.configs['api_token']),
+            'Content-Type': 'application/json',
+        }
+
     def get_settings_path(self):
         return os.path.join(os.getcwd(), 'config', 'datakit-dworld.json')
 

--- a/datakit_dworld/push.py
+++ b/datakit_dworld/push.py
@@ -73,13 +73,10 @@ class Push(DworldMixin, CommandHelpers, Command):
     def upload_file(self, path, dataset_id):
         url = 'https://api.data.world/v0/uploads/{0}/files/{1}'.format(
             dataset_id, os.path.basename(path))
-        headers = {
-            'Authorization': 'Bearer {0}'.format(self.configs['api_token']),
-            'Content-Type': self.get_mime_type(path),
-        }
 
         with open(path, 'rb') as input_file:
-            r = requests.put(url, data=input_file, headers=headers)
+            r = requests.put(
+                url, data=input_file, headers=self.get_auth_headers())
 
         try:
             r.raise_for_status()

--- a/datakit_dworld/summary.py
+++ b/datakit_dworld/summary.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+import os
+
+from cliff.command import Command
+from datakit import CommandHelpers
+import requests
+
+from datakit_dworld.dworld_mixin import DworldMixin
+
+
+class Summary(DworldMixin, CommandHelpers, Command):
+    "Update summary for dataset on data.world"
+
+    def take_action(self, parsed_args):
+        friendly_name = '{0}/{1}'.format(
+            self.configs['username'], self.get_project_slug())
+        try:
+            payload = self.build_payload(parsed_args)
+        except FileNotFoundError:
+            summary_path = self.get_summary_path()
+            self.log.warning(
+                'Summary file not found! Downloading existing summary.')
+            self.download_summary(summary_path)
+            return
+
+        self.log.info((
+            'Attempting to update summary for dataset '
+            '{0} on data.world').format(friendly_name))
+        summary_length = self.update_summary(
+            self.configs['username'], self.get_project_slug(), payload)
+        self.log.info('Updated summary ({0} bytes) for dataset {1}'.format(
+            summary_length, friendly_name))
+
+    def build_payload(self, parsed_args):
+        return {
+            'summary': self.read_summary_content(),
+        }
+
+    def download_summary(self, output_path):
+        url = 'https://api.data.world/v0/datasets/{0}/{1}'.format(
+            self.configs['username'], self.get_project_slug())
+
+        r = requests.get(url, headers=self.get_auth_headers())
+        r.raise_for_status()
+
+        try:
+            summary = r.json()['summary']
+        except KeyError:
+            self.log.warning(
+                'No summary found for this dataset! Using built-in template.')
+            template_path = os.path.join(
+                os.path.dirname(__file__), 'assets', 'summary_template.md')
+            with open(template_path, 'r') as template_file:
+                summary = template_file.read()
+
+        os.makedirs(os.path.dirname(output_path), exist_ok=True)
+        with open(output_path, 'w') as output_file:
+            bytes_written = output_file.write(summary)
+        self.log.info('Wrote {0} bytes to {1}'.format(
+            bytes_written, os.path.abspath(output_path)))
+
+    def update_summary(self, dataset_owner, dataset_id, payload):
+        url = 'https://api.data.world/v0/datasets/{0}/{1}'.format(
+            dataset_owner, dataset_id)
+
+        r = requests.patch(url, json=payload, headers=self.get_auth_headers())
+        r.raise_for_status()
+
+        return len(payload['summary'])
+
+    def get_project_slug(self):
+        try:
+            return self.get_settings_data()['slug']
+        except KeyError:
+            settings_path = os.path.abspath(self.get_settings_path())
+            raise KeyError(
+                'Couldn\'t find `slug` in your project-level config. '
+                'Make sure it exists in {0}.'.format(settings_path))
+
+    def get_summary_path(self):
+        return os.path.join(
+            self.get_project_path(), 'publish', 'distro_summary.md')
+
+    def read_summary_content(self):
+        with open(self.get_summary_path(), 'r') as summary_file:
+            return summary_file.read()

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
         'datakit.plugins': [
             'dworld create= datakit_dworld.create:Create',
             'dworld push= datakit_dworld.push:Push',
+            'dworld summary= datakit_dworld.summary:Summary',
         ]
     },
     install_requires=requirements,

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# from unittest import mock
+
+
+# from datakit_dworld.summary import Summary
+
+
+def test_summary(capsys):
+    """Sample pytest test function with a built-in pytest fixture as an argument.
+    """
+    # cmd = Greeting(None, None, cmd_name='dworld summary')
+    # parsed_args = mock.Mock()
+    # parsed_args.greeting = 'Hello world!'
+    # cmd.run(parsed_args)
+    # out, err = capsys.readouterr()
+    # assert 'Hello world!' in out


### PR DESCRIPTION
This wraps the data.world API call for updating datasets' metadata and allows users to edit their summaries locally as Markdown files. (Particularly ambitious users even could generate that Markdown automatically!)

h/t @kastanis for the nudge to make this happen!